### PR TITLE
Make output gofmt-compliant

### DIFF
--- a/main.go
+++ b/main.go
@@ -110,14 +110,27 @@ func generateFile(output string, localizations map[string]string) error {
 		return err
 	}
 
+	maxWidth := 0
+	for name := range localizations {
+		if len(name) > maxWidth {
+			maxWidth = len(name)
+		}
+	}
+
+	lineUp := func(name string) string {
+		return strings.Repeat(" ", maxWidth-len(name))
+	}
+
 	return packageTemplate.Execute(f, struct {
 		Timestamp     time.Time
 		Localizations map[string]string
 		Package       string
+		LineUp        func(string) string
 	}{
 		Timestamp:     time.Now(),
 		Localizations: localizations,
 		Package:       parent,
+		LineUp:        lineUp,
 	})
 }
 

--- a/template.go
+++ b/template.go
@@ -19,14 +19,14 @@ import (
 
 var localizations = map[string]string{
 {{- range $key, $element := .Localizations  }}
-	"{{ $key }}": "{{ $element }}",
+	"{{ $key }}":{{ call $.LineUp $key }} "{{ $element }}",
 {{- end }}
 }
 
 type Replacements map[string]interface{}
 
 type Localizer struct {
-	Locale	 string
+	Locale         string
 	FallbackLocale string
 	Localizations  map[string]string
 }
@@ -62,11 +62,11 @@ func (t Localizer) GetWithLocale(locale, key string, replacements ...*Replacemen
 		}
 	}
 
-        // If the str doesn't have any substitutions, no need to
-        // template.Execute.
+	// If the str doesn't have any substitutions, no need to
+	// template.Execute.
 	if strings.Index(str, "}}") == -1 {
-                return str
-        }
+		return str
+	}
 
 	return t.replace(str, replacements...)
 }


### PR DESCRIPTION
This PR fixes some stray whitespace in the template (and thus generated code). Also, map values are now lined up, so now the code fully complies the Go code style and passes gofmt without any changes.